### PR TITLE
Add scripts to provision clusters with STS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,8 @@ locals {
   cmd_dry_run = var.dry_run ? " --dry-run" : ""
   multizone = var.multi-zone-cluster ? " --multi-az" : ""
   privatelink = var.private-link ? " --private-link" : ""
-  clsuter_cmd = " --cluster-name ${local.cluster_name} --region ${var.region} --version ${var.ocp_version} --compute-nodes ${local.compute_nodes} --compute-machine-type ${local.compute_type} --machine-cidr ${var.machine-cidr} --service-cidr ${var.service-cidr} --pod-cidr ${var.pod-cidr} --host-prefix ${var.host-prefix} --etcd-encryption ${local.multizone} ${local.privatelink} ${local.cmd_dry_run} --yes"
+  sts = var.secure-token-service ? " --sts" : ""
+  clsuter_cmd = " --cluster-name ${local.cluster_name} --region ${var.region} --version ${var.ocp_version} --compute-nodes ${local.compute_nodes} --compute-machine-type ${local.compute_type} --machine-cidr ${var.machine-cidr} --service-cidr ${var.service-cidr} --pod-cidr ${var.pod-cidr} --host-prefix ${var.host-prefix} --etcd-encryption ${local.multizone} ${local.privatelink} ${local.sts} ${local.cmd_dry_run} --yes"
   cluster_vpc_cmd = var.existing_vpc ? join(" ", [local.clsuter_cmd, " --subnet-ids ", local.join_subnets]) : ""
   create_clsuter_cmd = var.existing_vpc ? local.cluster_vpc_cmd : local.clsuter_cmd
 
@@ -17,8 +18,8 @@ locals {
   cluster_type_tag      = "ocp"
   cluster_version       = "${var.ocp_version}_openshift"
 
-
 }
+
 module "setup_clis" {
   source = "github.com/cloud-native-toolkit/terraform-util-clis.git"
 
@@ -38,8 +39,9 @@ resource "null_resource" "create-rosa-cluster" {
     bin_dir            = local.bin_dir
     create_clsuter_cmd = local.create_clsuter_cmd
     cluster_name       = local.cluster_name
-    rosa_token        = var.rosa_token
-    region          = var.region
+    rosa_token         = var.rosa_token
+    region             = var.region
+    setup_sts          = tostring(var.secure-token-service)
   }
   depends_on = [
     module.setup_clis,
@@ -54,23 +56,44 @@ resource "null_resource" "create-rosa-cluster" {
     ${self.triggers.bin_dir}/rosa verify quota --region=${self.triggers.region}
     ${self.triggers.bin_dir}/rosa init --region=${self.triggers.region}
     ${self.triggers.bin_dir}/rosa create cluster ${self.triggers.create_clsuter_cmd}
+
+
+    if [ "${self.triggers.setup_sts}" = "true" ]; then
+      echo "Setting up STS resources"
+
+      cluster_id=$(${self.triggers.bin_dir}/rosa describe cluster -c ${self.triggers.cluster_name} -o json | ${self.triggers.bin_dir}/jq -r .id)
+
+      ${self.triggers.bin_dir}/rosa create operator-roles --mode auto -c $cluster_id --yes
+      ${self.triggers.bin_dir}/rosa create oidc-provider  --mode auto -c $cluster_id --yes
+    fi
     EOF
   }
 
- provisioner "local-exec" {
+  provisioner "local-exec" {
     when    = destroy
     command = <<-EOF
-      
+
+      ${self.triggers.bin_dir}/rosa login --token=${self.triggers.rosa_token}
+      ${self.triggers.bin_dir}/rosa init --region=${self.triggers.region}
+
+      cluster_id=$(${self.triggers.bin_dir}/rosa describe cluster -c ${self.triggers.cluster_name} -o json | ${self.triggers.bin_dir}/jq -r .id)
+
       ${path.module}/scripts/delete_cluster.sh ${self.triggers.cluster_name}  ${self.triggers.region} ${self.triggers.rosa_token} ${self.triggers.bin_dir} 
       
+      if [ "${self.triggers.setup_sts}" = "true" ]; then
+        echo "Tearing down STS resources"
+        ${self.triggers.bin_dir}/rosa delete operator-roles --mode auto -c $cluster_id --yes
+        ${self.triggers.bin_dir}/rosa delete oidc-provider  --mode auto -c $cluster_id --yes
+      fi
     EOF
     
   } 
 }
 
+
 resource null_resource wait-for-cluster-ready {
  depends_on = [null_resource.create-rosa-cluster]
-  
+
    triggers = {
     bin_dir            = local.bin_dir
     cluster_name       = local.cluster_name

--- a/variables.tf
+++ b/variables.tf
@@ -116,3 +116,10 @@ variable "private-link" {
 }
 
 
+variable "secure-token-service" {
+  type = bool
+  default = false
+  description = "Use AWS Security Token Service (STS) instead of IAM credentials to deploy your cluster"
+}
+
+


### PR DESCRIPTION
This commits adds a boolean variable to enable
STS that is false by default for backward compatibility
of this module.

The calls to the rosa CLI had to be added to the script that
creates and deletes the cluster instead of a new resource in
terraform because the STS roles and oidc provider can only be
deleted using the cluster ID that is only known after the
cluster is created.