### PR TITLE
Add option to enable autoscaling of compute nodes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,8 @@ locals {
   cmd_dry_run = var.dry_run ? " --dry-run" : ""
   multizone = var.multi-zone-cluster ? " --multi-az" : ""
   privatelink = var.private-link ? " --private-link" : ""
-  clsuter_cmd = " --cluster-name ${local.cluster_name} --region ${var.region} --version ${var.ocp_version} --compute-nodes ${local.compute_nodes} --compute-machine-type ${local.compute_type} --machine-cidr ${var.machine-cidr} --service-cidr ${var.service-cidr} --pod-cidr ${var.pod-cidr} --host-prefix ${var.host-prefix} --etcd-encryption ${local.multizone} ${local.privatelink} ${local.cmd_dry_run} --yes"
+  autoscaling = var.enable-autoscaling ? " --enable-autoscaling --min-replicas ${var.min-replicas} --max-replicas ${var.max-replicas}" : " --compute-nodes ${local.compute_nodes}"
+  clsuter_cmd = " --cluster-name ${local.cluster_name} --region ${var.region} --version ${var.ocp_version} ${local.autoscaling} --compute-machine-type ${local.compute_type} --machine-cidr ${var.machine-cidr} --service-cidr ${var.service-cidr} --pod-cidr ${var.pod-cidr} --host-prefix ${var.host-prefix} --etcd-encryption ${local.multizone} ${local.privatelink} ${local.cmd_dry_run} --yes"
   cluster_vpc_cmd = var.existing_vpc ? join(" ", [local.clsuter_cmd, " --subnet-ids ", local.join_subnets]) : ""
   create_clsuter_cmd = var.existing_vpc ? local.cluster_vpc_cmd : local.clsuter_cmd
 

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,24 @@ variable "no_of_compute_nodes" {
   description = "Number of worker nodes to be provisioned"
 }
 
+variable "enable-autoscaling" {
+  type = bool
+  default = false
+  description = "Enable autoscaling of compute nodes."
+}
+
+variable "min-replicas" {
+  type        = number
+  default     = 2
+  description = "Minimum number of compute nodes."
+}
+
+variable "max-replicas" {
+  type        = number
+  default     = 2
+  description = "Maximum number of compute nodes."
+}
+
 variable "compute-machine-type" {
   type        = string
   default     = "m5.xlarge"


### PR DESCRIPTION
This commits adds a boolean variable to turn on autoscaling that defaults to false for backward compatibility.
In addition, it adds a min-replicas and a max-replicas variable to set the scaling range. When enable-austoscaling
is enabled, the no_of_compute_nodes is ignored.