### PR TITLE
Add option to enable private clusters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,8 @@ locals {
   cmd_dry_run = var.dry_run ? " --dry-run" : ""
   multizone = var.multi-zone-cluster ? " --multi-az" : ""
   privatelink = var.private-link ? " --private-link" : ""
-  clsuter_cmd = " --cluster-name ${local.cluster_name} --region ${var.region} --version ${var.ocp_version} --compute-nodes ${local.compute_nodes} --compute-machine-type ${local.compute_type} --machine-cidr ${var.machine-cidr} --service-cidr ${var.service-cidr} --pod-cidr ${var.pod-cidr} --host-prefix ${var.host-prefix} --etcd-encryption ${local.multizone} ${local.privatelink} ${local.cmd_dry_run} --yes"
+  private = var.private ? " --private" : ""
+  clsuter_cmd = " --cluster-name ${local.cluster_name} --region ${var.region} --version ${var.ocp_version} --compute-nodes ${local.compute_nodes} --compute-machine-type ${local.compute_type} --machine-cidr ${var.machine-cidr} --service-cidr ${var.service-cidr} --pod-cidr ${var.pod-cidr} --host-prefix ${var.host-prefix} --etcd-encryption ${local.multizone} ${local.privatelink} ${local.cmd_dry_run} ${local.private} --yes"
   cluster_vpc_cmd = var.existing_vpc ? join(" ", [local.clsuter_cmd, " --subnet-ids ", local.join_subnets]) : ""
   create_clsuter_cmd = var.existing_vpc ? local.cluster_vpc_cmd : local.clsuter_cmd
 

--- a/variables.tf
+++ b/variables.tf
@@ -116,3 +116,12 @@ variable "private-link" {
 }
 
 
+variable "private" {
+  type = bool
+  default = false
+  description = <<-EOF
+  Restrict master API endpoint and application routes to direct, private connectivity.
+  When using this option terraform has to be run from a host that has access to the
+  private subnets
+  EOF
+}


### PR DESCRIPTION
This commit adds a variable that allows the usage of the --private command line flag that instructs the ROSA CLI to create a cluster that has no public endpoint. The variable defaults to false for backward compatibility.